### PR TITLE
Fix build hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ NAME = sunfoxcz/ipmiview
 all: build
 
 build:
-	docker build -t $(NAME):latest --rm -f Dockerfile .
+	docker build --ulimit "nofile=1024:524288" -t $(NAME):latest --rm -f Dockerfile .


### PR DESCRIPTION
Hang on "setting up python-meld3", similar to https://wiki.archlinux.org/title/Docker#Slow_golang_compilation